### PR TITLE
0.2.0 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 ## Changelog:
 
+### 0.2.0 - 2023-4-3:
+
+**Changed**
+- `status_logger.py` - updated logger file handler to be optionally initialized by environment variable. Updated logger file handler to rotating log file handler.
+- `sample.env.txt` - Added new `status_logger` related environment variables.
+- `sample-service-file.txt` - Updated the name in the unit description.
+- `sample_node_list.py` - Updated the remote node list to remove two and add one.
+- `monitor.py` - Refactored. Now also checks if a service node is decommissioned or deregistered. 
+
 ### 0.1.2 - 2022-12-26:
 
 **Changed**

--- a/monitor.py
+++ b/monitor.py
@@ -19,11 +19,30 @@ yag = yagmail.SMTP(FROM, FROM_PASS)
 
 
 def convert(seconds):
+    """
+    Convert an integer of seconds to a human-readable Hour:Minute:Second format.
+    :param seconds: Integer of seconds.
+    :return: string: Human-readable Hour:Minute:Second format.
+    """
     return time.strftime("%H:%M:%S", time.gmtime(seconds))
 
 
+def calculate_allowed_downtime_remaining(earned_downtime_blocks):
+    """
+    Calculates the amount of allowed downtime left for a decommissioned node before it is deregistered.
+    :param earned_downtime_blocks: Number of blocks of earned downtime left before deregistration.
+    :return float: Hours of downtime remaining rounded to two decimal places.
+    """
+    earned_downtime_hours = round( ( earned_downtime_blocks * 2 ) / 60, 2)
+    return earned_downtime_hours
+
+
 def node_selector(node_list):
-    """Connect to a Oxen remote node to get service node uptime data."""
+    """
+    Connect to a Oxen remote node to get service node uptime data.
+    :param node_list: List of Oxen remote nodes to query for service node data.
+    :return: string: URL of the oxen remote node that returned a 200 response.
+    """
     for x in node_list:
         try:
             payload = {}
@@ -34,19 +53,21 @@ def node_selector(node_list):
             else:
                 node = None
             return node
-        except KeyboardInterrupt:
-            sys.exit()
-        except requests.exceptions.Timeout as e:
-            status_logger.logger.exception("Exception occurred\n")
+        except requests.exceptions.Timeout:
+            status_logger.logger.exception("Timeout occurred\n")
             time.sleep(60)
             status_logger.logger.info("Reconnecting...")
             continue
-        except Exception as e:
+        except Exception:
             status_logger.logger.exception("Exception occurred\n")
 
 
 def no_node_alert():
-    """If no remote node is available for connection. Call this function to trigger an alert."""
+    """
+    If no remote node is available for connection. Call this function to trigger an alert.
+    :return: Void.
+    :raise: TypeError.
+    """
     status_logger.logger.warning("Unable to connect to a Oxen remote node.")
     no_node_subj = "Unable to connect to a Oxen remote node."
 
@@ -58,93 +79,169 @@ def no_node_alert():
     raise TypeError("Unable to connect to a Oxen remote node. Remote node cannot be 'None'.")
 
 
-def snode_checker(service_node_list, remote_node_url):
-    """Check our service node(s) uptime proofs and calculate time delta
-    since last uptime proof received."""
-    for i, item in enumerate(service_node_list):
-        try:
+def get_deregistered_snodes(service_node_list, current_snode_stats):
+    """
+    This function creates a list of deregistered snode pubkeys by comparing the service_node_list
+    and current_snode_stats.
+    :param service_node_list: The list of service node pubkeys that we are monitoring.
+    :param current_snode_stats: Dictionary of the JSON response we received from the remote node.
+    :return list: A list of deregistered service node pubkeys.
+    """
 
-            status_logger.logger.info(f"Checking SNode: {service_node_list[i]}")
+    #Get all the ed25519 pubkeys from the current_snode_stats and put into a temporary list.
+    active_pubkeys = []
+    for i in range(len(current_snode_stats['result']['service_node_states'])):
+        active_pubkeys.append(current_snode_stats['result']['service_node_states'][i]['pubkey_ed25519'])
 
-            # Get SNode data.		
-            sns = requests.post(remote_node_url,
-                                json={"jsonrpc": "2.0", "id": "0", "method": "get_service_nodes",
-                                      "params": {"service_node_pubkeys": [service_node_list[i]]}}, timeout=10).json()
+    deregistered_pubkeys = []
+    for pubkey in service_node_list:
+        if pubkey not in active_pubkeys:
+            deregistered_pubkeys.append(pubkey)
 
-            # Get SNode last uptime proof from SNode data.
-            snlup = sns['result']['service_node_states'][0]['last_uptime_proof']
-            snlup_time = time.strftime('%b %d, %Y - %I:%M:%S %p', time.localtime(snlup))
+    return deregistered_pubkeys
 
-            status_logger.logger.info(f"Your Oxen Service Node's last uptime proof was received at: {snlup_time}")
 
-            # Get monitor server's current time.
-            current_timestamp = int(time.time())
-            current_time = time.strftime('%b %d, %Y - %I:%M:%S %p', time.localtime(current_timestamp))
-
-            status_logger.logger.info(f"The monitor server's current time is: {current_time}")
-
-            # Compute time delta between current time and last uptime
-            uptime_proof_age = current_timestamp - snlup
-
-            # Convert uptime_proof_age to Human Readable Uptime Proof Age (hrupa) HH:MM:SS:
-            hrupa = convert(uptime_proof_age)
-
-            if uptime_proof_age > 3960:
-                status_logger.logger.warning(f"Service Node uptime proof is over one hour and six minutes old. " +
-                                             f"Check on the following Service Node immediately: " +
-                                             f"{service_node_list[i]}")
-
-                uptime_warning_subject = "URGENT: Oxen Service Node Uptime Proof not received"
-
-                uptime_warning_body = (f"Your Oxen Service Node uptime proof was last accepted by the network at " 
-                                       f"{snlup_time}, over {uptime_proof_age} seconds ago.\n\nCheck on the following "
-                                       f"Service Node immediately:\n\n{snode_list[i]}")
-
-                yag.send(TO, uptime_warning_subject, uptime_warning_body)
+def snode_stats_getter(service_node_list, remote_node_url):
+    """
+    Retrieves the stats for all the service nodes in the provided list.
+    :param service_node_list: List of service node public keys.
+    :param remote_node_url: The URL of the remote full node that we get data from.
+    :return service_node_stats: A dictionary of the JSON response received from the server.
+    """
+    try:
+        service_node_stats = requests.post(remote_node_url,
+                                 json={"jsonrpc": "2.0", "id": "0", "method": "get_service_nodes",
+                                 "params": {"service_node_pubkeys": service_node_list}}, timeout=10).json()
+    except requests.exceptions.Timeout:
+        status_logger.logger.exception("Timeout occurred\n")
+        time.sleep(60)
+        attempt = 0
+        while attempt < 10:
+            status_logger.logger.info("Reconnecting...")
+            remote_node_url = node_selector(remote_node_list)
+            if remote_node_url is None:
+                no_node_alert()
+                time.sleep(60)
+                attempt += 1
             else:
-                status_logger.logger.info(f"Oxen service node operational. Last uptime proof accepted at: "
+                status_logger.logger.info(f"Connected to: {remote_node_url}")
+                return snode_stats_getter(service_node_list, remote_node_url)
+
+    return service_node_stats
+
+def stats_evaluator(sns):
+    """
+    Evaluates the service node data provided by the snode_stats_getter()
+    :param sns: A dictionary of the JSON response received from the server.
+    :return:
+    """
+    if 'service_node_states' not in sns['result']:
+        # No nodes known to the network. Alert and bail.
+        status_logger.logger.warning('None of the service nodes we are monitoring are known the network.')
+        no_service_nodes_subject = 'URGENT: No service nodes known to the network'
+        no_service_nodes_body = 'None of the service nodes that are being monitored are known to the network.\n' \
+                                'Check on your service nodes immediately. They may be deregistered.\n' \
+                                'Sleeping for one hour.'
+        yag.send(TO, no_service_nodes_subject, no_service_nodes_body)
+        time.sleep(3600)
+
+    # Get the number of service nodes listed in the service_node_stats (sns):
+    service_nodes_count = len(sns['result']['service_node_states'])
+
+    # If this is true then one or more of our snodes are no longer known to the network. Send alert.
+    if len(snode_list) > service_nodes_count:
+        status_logger.logger.warning('One or more of our snodes have been deregistered. Sending alert.')
+        deregistered_snodes = get_deregistered_snodes(snode_list, sns)
+        deregistered_snodes_subject = f"URGENT: {len(deregistered_snodes)} service node(s) appear to be deregistered."
+        deregistered_snodes_body = "The following service node(s) appear to be deregistered. If this is expected, " \
+                "the only action required is to remove the below listed key(s) from your service node monitor.\n" \
+                "If this is not expected, please check the following service nodes immediately as they are most " \
+                "likely deregistered.\n"
+
+        for pubkey in deregistered_snodes:
+            deregistered_snodes_body += f"\t- {pubkey}\n"
+
+        yag.send(TO, deregistered_snodes_subject, deregistered_snodes_body)
+
+
+    # Get the last uptime proof for each snode from the response data:
+    for i in range(service_nodes_count):
+        current_snode = sns['result']['service_node_states'][i]['pubkey_ed25519']
+        status_logger.logger.info(f"Checking service node: {current_snode}")
+
+        snlup = sns['result']['service_node_states'][i]['last_uptime_proof']
+        snlup_time = time.strftime('%b %d, %Y - %I:%M:%S %p', time.localtime(snlup))
+
+        # Check if it is decommissioned first:
+        if not sns['result']['service_node_states'][i]['active'] and 0 == snlup:
+            # Snode is decommissioned. Send alert and include the amount of downtime remaining.
+            status_logger.logger.warning(f"{current_snode} is decommissioned. Sending alert.")
+            downtime_hours_remaining = calculate_allowed_downtime_remaining(
+                sns['result']['service_node_states'][i]['earned_downtime_blocks']
+            )
+            decommissioned_snode_subject = "URGENT: Service node is decommissioned."
+            decommissioned_snode_body = f"The following service node is decommissioned:\n\n" \
+                f"{current_snode}\n\n" \
+                f"Allowed downtime remaining: {downtime_hours_remaining} hours."
+            yag.send(TO, decommissioned_snode_subject, decommissioned_snode_body)
+            continue
+
+        status_logger.logger.info(f"Your Oxen Service Node's last uptime proof was received at: {snlup_time}")
+
+        # Get monitor server's current time.
+        current_timestamp = int(time.time())
+        current_time = time.strftime('%b %d, %Y - %I:%M:%S %p', time.localtime(current_timestamp))
+
+        status_logger.logger.info(f"The monitor server's current time is: {current_time}")
+
+        # Compute time delta between current time and last uptime
+        uptime_proof_age = current_timestamp - snlup
+
+        # Convert uptime_proof_age to Human Readable Uptime Proof Age (hrupa) HH:MM:SS:
+        hrupa = convert(uptime_proof_age)
+
+        if uptime_proof_age > 3960:
+            status_logger.logger.warning(f"Service Node uptime proof is over one hour and six minutes old. " +
+                                            f"Check on the following Service Node immediately: " +
+                                            f"{current_snode}")
+
+            uptime_warning_subject = "URGENT: Oxen Service Node Uptime Proof not received"
+
+            uptime_warning_body = (f"Your Oxen Service Node uptime proof was last accepted by the network at " 
+                                    f"{snlup_time}, over {uptime_proof_age} seconds ago.\n\nCheck on the following "
+                                    f"Service Node immediately:\n\n{current_snode}")
+
+            yag.send(TO, uptime_warning_subject, uptime_warning_body)
+        else:
+            status_logger.logger.info(f"Oxen service node operational. Last uptime proof accepted at: "
                                           f"{snlup_time}. Last uptime proof accepted {hrupa} ago.")
-        except KeyboardInterrupt:
-            sys.exit()
-        except requests.exceptions.Timeout as e:
-            status_logger.logger.exception("Exception occurred\n")
-            time.sleep(60)
-            try:
-                status_logger.logger.info("Reconnecting...")
-                url = node_selector(remote_node_list)
-                if url is None:
-                    no_node_alert()
-                else:
-                    status_logger.logger.info(f"Connected to: {url}")
-            except TypeError as error:
-                status_logger.logger.exception("Exception occurred\n")
-                sys.exit()
-            except Exception as e:
-                status_logger.logger.exception("Exception occurred\n")
-    time.sleep(300)
+            status_logger.logger.info('-' * 130)
+
+
+def main():
+    try:
+        url = node_selector(remote_node_list)
+        if url is None:
+            no_node_alert()
+        else:
+            status_logger.logger.info(f"Connected to: {url}")
+            status_logger.logger.info("Getting your Oxen Service Node last uptime proof.")
+
+        response = snode_stats_getter(snode_list, url)
+
+        stats_evaluator(response)
+
+        time.sleep(300)
+    except KeyboardInterrupt:
+        sys.exit()
+    except TypeError:
+        status_logger.logger.exception("Exception occurred\n")
+        sys.exit()
+    except Exception:
+        status_logger.logger.exception("Exception occurred\n")
 
 
 if __name__ == "__main__":
 
     while True:
-        try:
-            url = node_selector(remote_node_list)
-            if url is None:
-                no_node_alert()
-            else:
-                status_logger.logger.info(f"Connected to: {url}")
-                status_logger.logger.info("Getting your Oxen Service Node last uptime proof.")
-        except KeyboardInterrupt:
-            sys.exit()
-        except TypeError as error:
-            status_logger.logger.exception("Exception occurred\n")
-            sys.exit()
-        except Exception as e:
-            status_logger.logger.exception("Exception occurred\n")
-
-        try:
-            snode_checker(snode_list, url)
-        except KeyboardInterrupt:
-            sys.exit()
-        except Exception as e:
-            status_logger.logger.exception("Exception occurred\n")
+        main()

--- a/sample-service-file.txt
+++ b/sample-service-file.txt
@@ -1,5 +1,5 @@
 [Unit]
-Description=Loki Service Node Monitor
+Description=Oxen Service Node Monitor
 After=multi-user.target
 
 [Service]

--- a/sample.env.txt
+++ b/sample.env.txt
@@ -2,6 +2,10 @@
 # Set to WARNING for warnings, errors, and exceptions.
 LOG_LEVEL=WARNING
 
+# Set to SCREEN to initialize logger file handler,
+# otherwise set to SYSTEM to use system journal.
+RUNNING=SCREEN
+
 ### Yagmail Email Alerts ENV Vars
 # From address:
 FROM_ADDRESS=sendingfrom@gmail.com

--- a/sample.env.txt
+++ b/sample.env.txt
@@ -6,6 +6,12 @@ LOG_LEVEL=WARNING
 # otherwise set to SYSTEM to use system journal.
 RUNNING=SCREEN
 
+# Set max log file size in bytes. Ex: 1 megabyte == 1000000
+LOG_SIZE=1000000
+
+# Set number of log backup files to keep as part of log rotation.
+LOG_BACKUPS=5
+
 ### Yagmail Email Alerts ENV Vars
 # From address:
 FROM_ADDRESS=sendingfrom@gmail.com

--- a/sample_node_list.py
+++ b/sample_node_list.py
@@ -10,9 +10,8 @@ change them, or add more."""
 remote_node_list = [
     'http://oxen.observer:22023/json_rpc',
     'http://public.loki.foundation:22023/json_rpc',
-    'http://nodes.hashvault.pro:22023/json_rpc',
     'http://imaginary.stream:22023/json_rpc',
-    'http://node.loki-pool.com:18081/json_rpc',
     'http://lokiblocks.com:22023/json_rpc',
     'http://explorer.oxen.aussie-pools.com:18081/json_rpc',
+    'http://oxen.caliban.org:22023/json_rpc',
 ]

--- a/status_logger.py
+++ b/status_logger.py
@@ -12,18 +12,15 @@ logger = logging.getLogger(__name__)
 logger_level = logging.getLevelName(LOG_LEVEL)
 logger.setLevel(logger_level)
 
-
-# Handler
+# Console handler
 c_handler = logging.StreamHandler()
 c_handler.setLevel(logging.DEBUG)
 
-
-# Create formatters and add it to handlers
+# Create formatter and add it to handler
 c_format = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 c_handler.setFormatter(c_format)
 
-
-# Add handlers to the logger
+# Add handler to the logger
 logger.addHandler(c_handler)
 
 if RUNNING == 'SCREEN':

--- a/status_logger.py
+++ b/status_logger.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging.handlers
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -7,6 +7,8 @@ load_dotenv()
 # Variables
 LOG_LEVEL = os.getenv('LOG_LEVEL')
 RUNNING = os.getenv('RUNNING')
+LOG_SIZE = int(os.getenv('LOG_SIZE'))
+LOG_BACKUPS = int(os.getenv('LOG_BACKUPS'))
 
 logger = logging.getLogger(__name__)
 logger_level = logging.getLevelName(LOG_LEVEL)
@@ -25,7 +27,8 @@ logger.addHandler(c_handler)
 
 if RUNNING == 'SCREEN':
     # Initialize logging file handler and file formatter
-    f_handler = logging.FileHandler('status.log')
+    # RotateFileHandler: status.log, append, LOG_SIZE, LOG_BACKUPS.
+    f_handler = logging.handlers.RotatingFileHandler("status.log", "a", LOG_SIZE, LOG_BACKUPS)
     f_handler.setLevel(logging.DEBUG)
     f_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                                  datefmt='%a %b %d %Y - %I:%M:%S %p')

--- a/status_logger.py
+++ b/status_logger.py
@@ -6,29 +6,37 @@ load_dotenv()
 
 # Variables
 LOG_LEVEL = os.getenv('LOG_LEVEL')
+RUNNING = os.getenv('RUNNING')
 
 logger = logging.getLogger(__name__)
 logger_level = logging.getLevelName(LOG_LEVEL)
 logger.setLevel(logger_level)
 
 
-# Handlers
+# Handler
 c_handler = logging.StreamHandler()
-f_handler = logging.FileHandler('status.log')
-c_handler.setLevel(logging.INFO)
-f_handler.setLevel(logging.INFO)
+c_handler.setLevel(logging.DEBUG)
+
 
 # Create formatters and add it to handlers
 c_format = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
-f_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                             datefmt='%a %b %d %Y - %I:%M:%S %p')
 c_handler.setFormatter(c_format)
-f_handler.setFormatter(f_format)
+
 
 # Add handlers to the logger
 logger.addHandler(c_handler)
-logger.addHandler(f_handler)
+
+if RUNNING == 'SCREEN':
+    # Initialize logging file handler and file formatter
+    f_handler = logging.FileHandler('status.log')
+    f_handler.setLevel(logging.DEBUG)
+    f_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                                 datefmt='%a %b %d %Y - %I:%M:%S %p')
+    f_handler.setFormatter(f_format)
+    logger.addHandler(f_handler)
 
 if __name__ == "__main__":
+    logger.debug("This is an DEBUG log.")
     logger.info("This is an INFO log.")
     logger.warning("This is a WARNING log.")
+    logger.error("This is an ERROR log.")


### PR DESCRIPTION
This PR adds decommission and de-registration checks for service nodes being monitored. 

It also adds a new environment variable and a refactored status logger that together only initialize a logger file handler if the environment variable is set to a specific value. Otherwise the stream handler is the only logger initialized. This is handy if you run the monitor as a system service as the logging is captured by the systemd journal. That way you aren't duplicating logging and using up disk space. 

For users running the monitor in a screen the logger file handler has been replaced with a log rotator to keep logs neat and tidy. The log file size and number of log file backups to keep is controlled via environment variables. See the `sample-env.txt` file for details on these new variables.

Lastly, the `remote_node_list` has been updated. I've removed two nodes that are no longer online and added `oxen.caliban.org` node to the list to use for fetching service node data. 