### PR TITLE
Update logging format of happy path to improve readability

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ## Changelog:
 
+### 0.2.5 - 2024-04-16:
+
+**Changed**
+- `requirements.txt` - Bump idna from 3.3 to 3.7 [PR 20](https://github.com/crypto-ali/oxen-snode-monitor/pull/20)
+- `monitor.py` - Update logging of the happy path to improve readability. [PR 21](https://github.com/crypto-ali/oxen-snode-monitor/pull/21)
+
 ### 0.2.4 - 2023-11-09:
 
 **Changed**

--- a/monitor.py
+++ b/monitor.py
@@ -214,7 +214,8 @@ def stats_evaluator(sns):
             yag.send(TO, uptime_warning_subject, uptime_warning_body)
         else:
             status_logger.logger.info(f"Oxen service node operational. Last uptime proof accepted at: "
-                                          f"{snlup_time}. Last uptime proof accepted {hrupa} ago.")
+                                          f"{snlup_time}.")
+            status_logger.logger.info(f"Last uptime proof accepted {hrupa} ago.")
             status_logger.logger.info('-' * 130)
 
 


### PR DESCRIPTION
This PR moves the last sentence of the happy path logging into it's own logger call to improve the readability of the happy path logs. It is now easier to see when the last uptime proof was accepted in human readable elapsed time.

Before:

```
status_logger - INFO - Checking service node: a1b2c3
status_logger - INFO - Your Oxen Service Node's last uptime proof was received at: Apr 16, 2024 - 09:35:56 AM
status_logger - INFO - The monitor server's current time is: Apr 16, 2024 - 10:31:56 AM
status_logger - INFO - Oxen service node operational. Last uptime proof accepted at: Apr 16, 2024 - 09:35:56 AM. Last uptime proof accepted 00:56:00 ago.
```

After:

```
status_logger - INFO - Checking service node: a1b2c3
status_logger - INFO - Your Oxen Service Node's last uptime proof was received at: Apr 16, 2024 - 09:35:56 AM
status_logger - INFO - The monitor server's current time is: Apr 16, 2024 - 10:31:56 AM
status_logger - INFO - Oxen service node operational. Last uptime proof accepted at: Apr 16, 2024 - 09:35:56 AM.
status_logger - INFO - Last uptime proof accepted 00:56:00 ago.
```

This PR also updates the changelog to reflect this change and the dependency bump in PR #20.  